### PR TITLE
DB: loader wrong user

### DIFF
--- a/svip_db_backups/restoredump.sh
+++ b/svip_db_backups/restoredump.sh
@@ -27,4 +27,4 @@ if [ $? -ne 0 ]; then
   fi
 fi
 
-createdb ${TARGET_DB}; time pg_restore -j 16 -F c -d ${TARGET_DB} $1
+createdb -U postgres ${TARGET_DB}; time pg_restore -U postgres -j 16 -F c -d ${TARGET_DB} $1


### PR DESCRIPTION
Fixed a small issue with pgsql command not specifying the user and defaulting to "roo"